### PR TITLE
Fix poetry install errors

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,7 @@
 name = "eq-runner-mock-cir"
 version = "0.1.0"
 description = "ONS Digital eQ Runner Mock CIR"
-authors = ["http://onsdigital.github.io"]
+authors = ["ONSDigital"]
 readme = "README.md"
 
 [tool.poetry.dependencies]


### PR DESCRIPTION
### What is the context of this PR?
This PR updates the authors in the pyproject.toml file and adds an __init__.py file to fix some `poetry install` errors

<img width="549" alt="Screenshot 2024-04-24 at 09 59 43" src="https://github.com/ONSdigital/eq-runner-mock-cir/assets/42928680/4c893021-d21d-4414-af6f-957a674f6d7a">

<img width="1207" alt="Screenshot 2024-04-24 at 10 02 03" src="https://github.com/ONSdigital/eq-runner-mock-cir/assets/42928680/f5563f76-8be4-46b2-a10b-bf74aed975e3">


### How to review
Run `poetry install` and check that dependencies install without error
